### PR TITLE
Add CSP Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,13 @@ Then run:
 vercel --prod
 ```
 To deploy to production.
+
+## Content Security Policy Headers
+
+To ensure better security, we apply Content-Security-Policy (CSP) headers in Vercel, using the *vercel.json* file as described [here](https://vercel.com/docs/cli#project-configuration/headers). Since we use some inline code (both Javascript and CSS) we need to include the SHA hashes that match the following pieces of code:
+
+`this.media='all'` (Google Fonts load) = `'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='`
+
+(Inline CSS in test result HTML page) = `'sha256-Vv5TW3/Rmik7SBeZlrkFStK4ozYD3t6SlHE6tlWhW8Y='`
+
+_*Note:* We also fallback to `unsafe-inline` for `script-src` for browsers that don't support hashes._

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
             },
             {   
                 "key" : "Content-Security-Policy",
-                "value" : "style-src 'self' 'sha256-Vv5TW3/Rmik7SBeZlrkFStK4ozYD3t6SlHE6tlWhW8Y=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; object-src 'none'"
+                "value" : "style-src 'self' 'sha256-Vv5TW3/Rmik7SBeZlrkFStK4ozYD3t6SlHE6tlWhW8Y=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'strict-dynamic' 'unsafe-inline'; object-src 'none'"
             }
             ]
         }

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
             },
             {   
                 "key" : "Content-Security-Policy",
-                "value" : "style-src 'self' 'sha256-Vv5TW3/Rmik7SBeZlrkFStK4ozYD3t6SlHE6tlWhW8Y=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'strict-dynamic' 'unsafe-inline'; object-src 'none'"
+                "value" : "style-src 'self' 'sha256-Vv5TW3/Rmik7SBeZlrkFStK4ozYD3t6SlHE6tlWhW8Y=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc=' 'unsafe-inline'; object-src 'none'"
             }
             ]
         }

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
             },
             {   
                 "key" : "Content-Security-Policy",
-                "value" : "style-src 'self' 'sha256-Vv5TW3/Rmik7SBeZlrkFStK4ozYD3t6SlHE6tlWhW8Y=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='"
+                "value" : "style-src 'self' 'sha256-Vv5TW3/Rmik7SBeZlrkFStK4ozYD3t6SlHE6tlWhW8Y=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; object-src 'none'"
             }
             ]
         }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,25 @@
+{
+    "headers": [
+        {
+            "source": "/(.*)",
+            "headers" : [
+            {
+                "key" : "X-Content-Type-Options",
+                "value" : "nosniff"
+            },
+            {
+                "key" : "X-Frame-Options",
+                "value" : "SAMEORIGIN"
+            },
+            {
+                "key" : "X-XSS-Protection",
+                "value" : "1; mode=block"
+            },
+            {   
+                "key" : "Content-Security-Policy-Report-Only",
+                "value" : "style-src 'self' 'sha256-JOzLlPMErmaESDPXojMrIfRz/APutBSoFpHo1zKbbMc=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='"
+            }
+            ]
+        }
+    ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
             },
             {   
                 "key" : "Content-Security-Policy-Report-Only",
-                "value" : "style-src 'self' 'sha256-JOzLlPMErmaESDPXojMrIfRz/APutBSoFpHo1zKbbMc=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='"
+                "value" : "style-src 'self' 'sha256-JOzLlPMErmaESDPXojMrIfRz/APutBSoFpHo1zKbbMc=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='"
             }
             ]
         }

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
             },
             {   
                 "key" : "Content-Security-Policy-Report-Only",
-                "value" : "style-src 'self' 'sha256-JOzLlPMErmaESDPXojMrIfRz/APutBSoFpHo1zKbbMc=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='"
+                "value" : "style-src 'self' 'sha256-Vv5TW3/Rmik7SBeZlrkFStK4ozYD3t6SlHE6tlWhW8Y=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='"
             }
             ]
         }

--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,7 @@
                 "value" : "1; mode=block"
             },
             {   
-                "key" : "Content-Security-Policy-Report-Only",
+                "key" : "Content-Security-Policy",
                 "value" : "style-src 'self' 'sha256-Vv5TW3/Rmik7SBeZlrkFStK4ozYD3t6SlHE6tlWhW8Y=' https://fonts.googleapis.com https://*.fontawesome.com; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='"
             }
             ]


### PR DESCRIPTION
Added CSP headers by following the Vercel CLI docs, matching the SHAs for the Google Fonts loading and the inline CSS for the test results HTML page.