### PR TITLE
Update credentials links

### DIFF
--- a/source/index.liquid
+++ b/source/index.liquid
@@ -31,10 +31,10 @@ additional_gfonts: Indie+Flower
             <div><a class="bg-gray-900 hover:bg-gray-700 text-white text-5xl rounded shadow pt-1"
                     href="https://dev.to/ndsn"><i title="DEV" class="fab fa-fw fa-dev"></i></a></div>
             <div><a class="bg-white hover:bg-gray-200 border border-gray-500 border-opacity-50 text-gray-800 text-5xl rounded shadow pt-1"
-                    href="https://googlecloudcertified.credential.net/profile/0a0997a4f8b4ce5db4ded3ad1209b1762bac02a8"><i title="Google Cloud Certifications" class="fab fa-fw fa-google"></i></a>
+                    href="https://www.credly.com/users/tom-anderson.35310e2e"><i title="Google Cloud Certifications" class="fab fa-fw fa-google"></i></a>
             </div>
             <div><a class="bg-white hover:bg-gray-200 border border-gray-500 border-opacity-50 text-blue-600 text-5xl rounded shadow pt-1"
-                    href="https://www.youracclaim.com/users/thomas-anderson.64196b60"><i title="Microsoft Certifications" class="fab fa-fw fa-microsoft"></i></a>
+                    href="https://www.credly.com/users/tom-anderson.35310e2e"><i title="Microsoft Certifications" class="fab fa-fw fa-microsoft"></i></a>
             </div>
         </div>
         <div class="col-span-3 sm:col-span-5">


### PR DESCRIPTION
Microsoft and Google now use Credly for their certs, so links are identical (and updated!)